### PR TITLE
Create rake tasks to seed DB with CSV data

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,0 +1,3 @@
+class Invoice < ApplicationRecord
+
+end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,0 +1,3 @@
+class InvoiceItem < ApplicationRecord
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,3 @@
+class Item < ApplicationRecord
+
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,0 +1,3 @@
+class Merchant < ApplicationRecord
+
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,0 +1,3 @@
+class Transaction < ApplicationRecord
+
+end

--- a/db/migrate/20230410224300_create_items.rb
+++ b/db/migrate/20230410224300_create_items.rb
@@ -4,11 +4,10 @@ class CreateItems < ActiveRecord::Migration[5.2]
 
       t.string :name, null: false
       t.string :description, null: false
-      t.integer :sell_price, null: false
-      t.integer :merchant_id, null: false #created this column from data
+      t.integer :unit_price, null: false
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      # t.references :merchant, foreign_key: true, null: false
+      t.references :merchant, foreign_key: true, null: false
     end
   end
 end

--- a/db/migrate/20230410224300_create_items.rb
+++ b/db/migrate/20230410224300_create_items.rb
@@ -1,13 +1,14 @@
 class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
-      
+
       t.string :name, null: false
       t.string :description, null: false
       t.integer :sell_price, null: false
+      t.integer :merchant_id, null: false #created this column from data
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      t.references :merchant, foreign_key: true, null: false
+      # t.references :merchant, foreign_key: true, null: false
     end
   end
 end

--- a/db/migrate/20230410224305_create_invoices.rb
+++ b/db/migrate/20230410224305_create_invoices.rb
@@ -1,11 +1,12 @@
 class CreateInvoices < ActiveRecord::Migration[5.2]
   def change
     create_table :invoices do |t|
-      
+
       t.integer :status, null: false
+      t.integer :customer_id, null: false #created this column from CSV
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      t.references :customer, foreign_key: true, null: false
+      # t.references :customer, foreign_key: true, null: false
     end
   end
 end

--- a/db/migrate/20230410224305_create_invoices.rb
+++ b/db/migrate/20230410224305_create_invoices.rb
@@ -3,10 +3,9 @@ class CreateInvoices < ActiveRecord::Migration[5.2]
     create_table :invoices do |t|
 
       t.integer :status, null: false
-      t.integer :customer_id, null: false #created this column from CSV
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      # t.references :customer, foreign_key: true, null: false
+      t.references :customer, foreign_key: true, null: false
     end
   end
 end

--- a/db/migrate/20230410224632_create_invoice_items.rb
+++ b/db/migrate/20230410224632_create_invoice_items.rb
@@ -1,14 +1,16 @@
 class CreateInvoiceItems < ActiveRecord::Migration[5.2]
   def change
     create_table :invoice_items do |t|
-      
+
       t.integer :quantity, null: false
       t.integer :sold_price, null: false
       t.integer :status, null: false
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      t.references :item, foreign_key: true, null: false
-      t.references :invoice, foreign_key: true, null: false
+      t.integer :item_id, null: false #created this from CSV
+      t.integer :invoice_id, null: false #created this from CSV
+      # t.references :item, foreign_key: true, null: false
+      # t.references :invoice, foreign_key: true, null: false
     end
   end
 end

--- a/db/migrate/20230410224632_create_invoice_items.rb
+++ b/db/migrate/20230410224632_create_invoice_items.rb
@@ -3,14 +3,12 @@ class CreateInvoiceItems < ActiveRecord::Migration[5.2]
     create_table :invoice_items do |t|
 
       t.integer :quantity, null: false
-      t.integer :sold_price, null: false
+      t.integer :unit_price, null: false
       t.integer :status, null: false
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      t.integer :item_id, null: false #created this from CSV
-      t.integer :invoice_id, null: false #created this from CSV
-      # t.references :item, foreign_key: true, null: false
-      # t.references :invoice, foreign_key: true, null: false
+      t.references :item, foreign_key: true, null: false
+      t.references :invoice, foreign_key: true, null: false
     end
   end
 end

--- a/db/migrate/20230410225256_create_transactions.rb
+++ b/db/migrate/20230410225256_create_transactions.rb
@@ -3,12 +3,11 @@ class CreateTransactions < ActiveRecord::Migration[5.2]
     create_table :transactions do |t|
 
       t.string :credit_card_number, null: false
-      t.date :expiration_date
-      t.integer :invoice_id, null: false #created this from CSV
-      t.boolean :success, null: false
+      t.date :credit_card_expiration_date
+      t.boolean :result, null: false
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      # t.references :invoice, foreign_key: true, null: false
+      t.references :invoice, foreign_key: true, null: false
     end
   end
 end

--- a/db/migrate/20230410225256_create_transactions.rb
+++ b/db/migrate/20230410225256_create_transactions.rb
@@ -1,13 +1,14 @@
 class CreateTransactions < ActiveRecord::Migration[5.2]
   def change
     create_table :transactions do |t|
-     
+
       t.string :credit_card_number, null: false
       t.date :expiration_date
+      t.integer :invoice_id, null: false #created this from CSV
       t.boolean :success, null: false
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
-      t.references :invoice, foreign_key: true, null: false
+      # t.references :invoice, foreign_key: true, null: false
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,28 +28,24 @@ ActiveRecord::Schema.define(version: 2023_04_10_225256) do
     t.integer "status", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "item_id", null: false
-    t.bigint "invoice_id", null: false
-    t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
-    t.index ["item_id"], name: "index_invoice_items_on_item_id"
+    t.integer "item_id", null: false
+    t.integer "invoice_id", null: false
   end
 
   create_table "invoices", force: :cascade do |t|
     t.integer "status", null: false
+    t.integer "customer_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "customer_id", null: false
-    t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 
   create_table "items", force: :cascade do |t|
     t.string "name", null: false
     t.string "description", null: false
     t.integer "sell_price", null: false
+    t.integer "merchant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "merchant_id", null: false
-    t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 
   create_table "merchants", force: :cascade do |t|
@@ -61,16 +57,10 @@ ActiveRecord::Schema.define(version: 2023_04_10_225256) do
   create_table "transactions", force: :cascade do |t|
     t.string "credit_card_number", null: false
     t.date "expiration_date"
+    t.integer "invoice_id", null: false
     t.boolean "success", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "invoice_id", null: false
-    t.index ["invoice_id"], name: "index_transactions_on_invoice_id"
   end
 
-  add_foreign_key "invoice_items", "invoices"
-  add_foreign_key "invoice_items", "items"
-  add_foreign_key "invoices", "customers"
-  add_foreign_key "items", "merchants"
-  add_foreign_key "transactions", "invoices"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,28 +24,32 @@ ActiveRecord::Schema.define(version: 2023_04_10_225256) do
 
   create_table "invoice_items", force: :cascade do |t|
     t.integer "quantity", null: false
-    t.integer "sold_price", null: false
+    t.integer "unit_price", null: false
     t.integer "status", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "item_id", null: false
-    t.integer "invoice_id", null: false
+    t.bigint "item_id", null: false
+    t.bigint "invoice_id", null: false
+    t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
+    t.index ["item_id"], name: "index_invoice_items_on_item_id"
   end
 
   create_table "invoices", force: :cascade do |t|
     t.integer "status", null: false
-    t.integer "customer_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "customer_id", null: false
+    t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 
   create_table "items", force: :cascade do |t|
     t.string "name", null: false
     t.string "description", null: false
-    t.integer "sell_price", null: false
-    t.integer "merchant_id", null: false
+    t.integer "unit_price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "merchant_id", null: false
+    t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 
   create_table "merchants", force: :cascade do |t|
@@ -56,11 +60,17 @@ ActiveRecord::Schema.define(version: 2023_04_10_225256) do
 
   create_table "transactions", force: :cascade do |t|
     t.string "credit_card_number", null: false
-    t.date "expiration_date"
-    t.integer "invoice_id", null: false
-    t.boolean "success", null: false
+    t.date "credit_card_expiration_date"
+    t.boolean "result", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "invoice_id", null: false
+    t.index ["invoice_id"], name: "index_transactions_on_invoice_id"
   end
 
+  add_foreign_key "invoice_items", "invoices"
+  add_foreign_key "invoice_items", "items"
+  add_foreign_key "invoices", "customers"
+  add_foreign_key "items", "merchants"
+  add_foreign_key "transactions", "invoices"
 end

--- a/lib/tasks/csv_load.rake
+++ b/lib/tasks/csv_load.rake
@@ -1,0 +1,66 @@
+require 'csv'
+
+namespace :csv_load do
+  desc "imports customer data from CSV and creates Customer objects"
+  task customers: :environment do
+    file = "db/data/customers.csv"
+    CSV.foreach(file, headers: true, header_converters: :symbol) do |row|
+      details = row.to_hash
+      Customer.create!(details)
+    end
+  end
+
+  desc "imports merchant data from CSV and creates Merchant objects"
+  task merchants: :environment do
+    file = "db/data/merchants.csv"
+    CSV.foreach(file, headers: true, header_converters: :symbol) do |row|
+      details = row.to_hash
+      Merchant.create!(details)
+    end
+  end
+
+  desc "imports item data from CSV and creates Item objects"
+  task items: :environment do
+    file = "db/data/items.csv"
+    CSV.foreach(file, headers: ['id', 'name', 'description', 'sell_price',
+                                'merchant_id', 'created_at', 'updated_at'],
+                header_converters: :symbol) do |row|
+      details = row.to_hash
+      Item.create!(details)
+    end
+  end
+
+  desc "imports invoice data from CSV and creates Invoice objects"
+  task invoices: :environment do
+    file = "db/data/invoices.csv"
+    CSV.foreach(file, headers: true, header_converters: :symbol) do |row|
+      details = row.to_hash
+      # need to handle status column values here?
+      Invoice.create!(details)
+    end
+  end
+
+  desc "imports invoice_item data from CSV and creates Invoice_Item objects"
+  task invoice_items: :environment do
+    file = "db/data/invoice_items.csv"
+    CSV.foreach(file, headers: ['id', 'item_id', 'invoice_id', 'quantity', 'sold_price', 'status',
+                                'created_at', 'updated_at'],
+                      header_converters: :symbol) do |row|
+      details = row.to_hash
+      # need to handle status column values here?
+      InvoiceItem.create!(details)
+    end
+  end
+
+  desc "imports transaction data from CSV and creates Transaction objects"
+  task transactions: :environment do
+    file = "db/data/transactions.csv"
+    CSV.foreach(file, headers: ['id', 'invoice_id', 'credit_card_number', 'expiration_date', 'success',
+                                'created_at', 'updated_at'],
+                      header_converters: :symbol) do |row|
+      details = row.to_hash
+      # need to handle success boolean values here?
+      Transaction.create!(details)
+    end
+  end
+end

--- a/lib/tasks/csv_load.rake
+++ b/lib/tasks/csv_load.rake
@@ -63,4 +63,14 @@ namespace :csv_load do
       Transaction.create!(details)
     end
   end
+
+  desc "imports all of the CSVs and creates records for all six tables"
+  task all: :environment do
+    Rake::Task["csv_load:customers"].execute
+    Rake::Task["csv_load:merchants"].execute
+    Rake::Task["csv_load:items"].execute
+    Rake::Task["csv_load:invoices"].execute
+    Rake::Task["csv_load:invoice_items"].execute
+    Rake::Task["csv_load:transactions"].execute
+  end
 end


### PR DESCRIPTION
This PR adds a csv_load rake file to the app with tasks to load each of the six included CSV data files, and one task to execute the six individual tasks in order and reset the primary key for all tables.

It also sets up model files for each table, and adjusts the migrations to re-name column names to match the default column names in each CSV.