### PR TITLE
Merchant invoice

### DIFF
--- a/app/controllers/invoice_items_controller.rb
+++ b/app/controllers/invoice_items_controller.rb
@@ -1,0 +1,15 @@
+class InvoiceItemsController < ApplicationController
+  def update
+    invoice_item = InvoiceItem.find(params[:id])
+
+    invoice_item.update(invoice_item_params)
+
+    redirect_to merchant_invoice_path(invoice_item.merchant, invoice_item.invoice)
+  end
+
+private
+
+  def invoice_item_params
+    params.require(:invoice_item).permit(:status)
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -26,6 +26,6 @@ class Invoice < ApplicationRecord
   end
 
   def total_revenue
-    invoice_items.sum('unit_price * quantity')
+    invoice_items.sum('unit_price * quantity / 100')
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,7 @@ class Item < ApplicationRecord
   validates :unit_price, presence: true, numericality: true
 
   def find_sold_price(invoice)
-    invoice_items.where(invoice_id: invoice.id).pluck(:unit_price)
+    invoice_items.where(invoice_id: invoice.id).pluck(:unit_price).first.fdiv(100)
   end
 
   def quantity_sold(invoice)

--- a/app/views/merchant/invoices/index.html.erb
+++ b/app/views/merchant/invoices/index.html.erb
@@ -1,9 +1,6 @@
 <h2><%= @merchant.name %> Invoices</h2>
 <% @merchant.invoices.each do |invoice| %>
   <div id="invoice-<%= invoice.id %>">
-    <h3><%= link_to "ID: #{invoice.id}", merchant_invoices_path(@merchant.id) %></h3>
-    <p>Status: <%= invoice.status %></p>
-    <p>Customer: <%= invoice.customer_name %></p>
-    <p>Created at: <%= invoice.created_at %></p>
+    <h3><%= link_to "ID: #{invoice.id}", merchant_invoice_path(@merchant, invoice) %></h3>
   </div>
 <% end %>

--- a/app/views/merchant/invoices/show.html.erb
+++ b/app/views/merchant/invoices/show.html.erb
@@ -20,11 +20,13 @@
     <p>Unit Price: <%= number_to_currency(invoice_item.item.find_sold_price(@invoice)) %></p>
     <p>Status: <%= invoice_item.item.invoice_item_status(@invoice).first %></p>
     
-    <p>Update Invoice Item Status</p>
-    <%= form_with url: "/merchants/#{@merchant.id}/invoices/#{@invoice.id}", method: :patch, local: true do |form| %>
-      <%= form.select :status, ['pending', 'packaged', 'shipped'], selected: invoice_item.status %>
-      <%= form.submit "Update Item Status" %>
-      <br>
-    <% end %>
+    <div id="selector">
+      <p>Update Invoice Item Status</p>
+      <%= form_with model: invoice_item, url: invoice_item_path(invoice_item), method: :patch, local: true do |form| %>
+        <%= form.select :status, ['Pending', 'Packaged', 'Shipped'], selected: invoice_item.status %>
+        <%= form.submit "Update Item Status" %>
+        <br>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/app/views/merchant/invoices/show.html.erb
+++ b/app/views/merchant/invoices/show.html.erb
@@ -10,3 +10,13 @@
   <h3>Customer:</h3>
   <p><%= @invoice.customer_name %></p>
 </div>
+
+<h3>Items on this Invoice:</h3>
+<% @invoice.items.each do |item| %>
+  <div id="item-info-<%= item.id %>">
+    <p>Item Name: <%= item.name %></p>
+    <p>Quantity: <%= item.quantity_sold(@invoice).first %></p>
+    <p>Unit Price: <%= number_to_currency(item.find_sold_price(@invoice)) %></p>
+    <p>Status: <%= item.invoice_item_status(@invoice).first %></p><br>
+  </div>
+<% end %>

--- a/app/views/merchant/invoices/show.html.erb
+++ b/app/views/merchant/invoices/show.html.erb
@@ -4,6 +4,7 @@
   <h3>Invoice #<%= @invoice.id %></h3>
   <p>Status: <%= @invoice.status %></p>
   <p>Created on: <%= @invoice.convert_created_at %></p>
+  <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %></p>
 </div>
 
 <div id="customer-info">
@@ -12,11 +13,18 @@
 </div>
 
 <h3>Items on this Invoice:</h3>
-<% @invoice.items.each do |item| %>
-  <div id="item-info-<%= item.id %>">
-    <p>Item Name: <%= item.name %></p>
-    <p>Quantity: <%= item.quantity_sold(@invoice).first %></p>
-    <p>Unit Price: <%= number_to_currency(item.find_sold_price(@invoice)) %></p>
-    <p>Status: <%= item.invoice_item_status(@invoice).first %></p><br>
+<% @invoice.invoice_items.each do |invoice_item| %>
+  <div id="item-info-<%= invoice_item.item.id %>">
+    <p>Item Name: <%= invoice_item.item.name %></p>
+    <p>Quantity: <%= invoice_item.item.quantity_sold(@invoice).first %></p>
+    <p>Unit Price: <%= number_to_currency(invoice_item.item.find_sold_price(@invoice)) %></p>
+    <p>Status: <%= invoice_item.item.invoice_item_status(@invoice).first %></p>
+    
+    <p>Update Invoice Item Status</p>
+    <%= form_with url: "/merchants/#{@merchant.id}/invoices/#{@invoice.id}", method: :patch, local: true do |form| %>
+      <%= form.select :status, ['pending', 'packaged', 'shipped'], selected: invoice_item.status %>
+      <%= form.submit "Update Item Status" %>
+      <br>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/merchant/invoices/show.html.erb
+++ b/app/views/merchant/invoices/show.html.erb
@@ -1,1 +1,12 @@
 <h3>Merchant Invoice Show Page</h3>
+
+<div id="invoice-info">
+  <h3>Invoice #<%= @invoice.id %></h3>
+  <p>Status: <%= @invoice.status %></p>
+  <p>Created on: <%= @invoice.convert_created_at %></p>
+</div>
+
+<div id="customer-info">
+  <h3>Customer:</h3>
+  <p><%= @invoice.customer_name %></p>
+</div>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -5,16 +5,20 @@
 <h3><%= link_to "Items Index", merchant_items_path(@merchant.id) %></h3>
 <h3><%= link_to "Invoices Index", merchant_invoices_path(@merchant.id) %></h3>
 
-<h3>Top 5 Customers</h3>
-<% @merchant.top_five_customers.each do |customer| %>
-  <div id="top-five-<%= customer.id %>">
-    <p><%= customer.name %> - <%= customer.transactions_count %> transactions</p>
-  </div>
-<% end %>
+<section id="top-five-cutomers">
+  <h3>Top 5 Customers</h3>
+  <% @merchant.top_five_customers.each do |customer| %>
+    <div id="top-five-<%= customer.id %>">
+      <p><%= customer.name %> - <%= customer.transactions_count %> transactions</p>
+    </div>
+  <% end %>
+</section>
 
-<h3>Items Ready to Ship</h3>
-<% @merchant.items_not_shipped.each do |invoice_item| %>
-  <div id="invoice-item-<%= invoice_item.id %>">
-    <p><%= invoice_item.item.name %> - Invoice #<%= link_to invoice_item.invoice.id, merchant_invoice_path(@merchant, invoice_item.invoice) %> - <%= invoice_item.invoice.convert_created_at %></p>
-  </div>
-<% end %>
+<section id="items-reader-to-ship">
+  <h3>Items Ready to Ship</h3>
+  <% @merchant.items_not_shipped.each do |invoice_item| %>
+    <div id="invoice-item-<%= invoice_item.id %>">
+      <p><%= invoice_item.item.name %> - Invoice #<%= link_to invoice_item.invoice.id, merchant_invoice_path(@merchant, invoice_item.invoice) %> - <%= invoice_item.invoice.convert_created_at %></p>
+    </div>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get '/admin', to: 'admin#index'
 
   resources :invoices, only: [:update]
+  resources :invoice_items, only: [:update]
 
   namespace :admin do
     resources :merchants, except: [:destroy, :create , :update]

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Admin Invoices Index Page', type: :feature do
         expect(page).to have_content(@invoice_item_3.status)
   
         expect(page).to_not have_content(@item_3.name)
-        expect(page).to_not have_content(@invoice_item_4.quantity)
+        expect(page).to_not have_content("Quantity Ordered: #{@invoice_item_4.quantity}")
         expect(page).to_not have_content(@invoice_item_4.unit_price)
       end
 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe 'Admin Invoices Index Page', type: :feature do
     @item_1 = create(:item, merchant_id: @merchant_1.id)
     @item_2 = create(:item, merchant_id: @merchant_1.id)
     @item_3 = create(:item, merchant_id: @merchant_1.id)
-    @invoice_item_1 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 5, unit_price: 5)
-    @invoice_item_2 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 10, unit_price: 10)
-    @invoice_item_3 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 15, unit_price: 15)
-    @invoice_item_4 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_3.id, quantity: 20, unit_price: 20)
+    @invoice_item_1 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 50, unit_price: 50)
+    @invoice_item_2 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 100, unit_price: 100)
+    @invoice_item_3 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 150, unit_price: 150)
+    @invoice_item_4 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_3.id, quantity: 200, unit_price: 200)
   end
 
   describe "Admin Invoice Show Page (User Story 33)" do

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Admin Invoices Index Page', type: :feature do
         expect(page).to have_content(@invoice_item_1.unit_price)
         expect(page).to have_content(@invoice_item_1.status)
   
-        expect(page).to_not have_content(@item_2.name)
+        expect(page).to_not have_content("Item name: #{@item_2.name}")
         expect(page).to_not have_content("Item sold price: #{@invoice_item_2.unit_price}")
       end
   

--- a/spec/features/merchant/invoices/index_spec.rb
+++ b/spec/features/merchant/invoices/index_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
     @item_3 = create(:item, merchant_id: @merchant_1.id)
     @item_4 = create(:item, merchant_id: @merchant_1.id)
     @item_5 = create(:item, merchant_id: @merchant_1.id)
-    @item_6 = create(:item, name: "Does not belong to merchant", merchant_id: @merchant_2.id)
+    @item_6 = create(:item, name: "Does not belong to merchant 1", merchant_id: @merchant_2.id)
     
     @customer_1 = create(:customer)
     @customer_2 = create(:customer)
@@ -75,13 +75,13 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
   end
 
   it 'when I visit a merchant invoice index page, I see all invoices with at least one of my merchant items (User Story 14)' do
-    expect(page).to have_link(@invoice_1.id)
-    expect(page).to have_link(@invoice_2.id)
-    expect(page).to have_link(@invoice_3.id)
-    expect(page).to have_link(@invoice_4.id)
-    expect(page).to have_link(@invoice_5.id)
-    expect(page).to have_link(@invoice_6.id)
-    expect(page).to have_link(@invoice_7.id)
-    expect(page).to_not have_link(@invoice_8.id)
+    expect(page).to have_link("ID: #{@invoice_1.id}")
+    expect(page).to have_link("ID: #{@invoice_2.id}")
+    expect(page).to have_link("ID: #{@invoice_3.id}")
+    expect(page).to have_link("ID: #{@invoice_4.id}")
+    expect(page).to have_link("ID: #{@invoice_5.id}")
+    expect(page).to have_link("ID: #{@invoice_6.id}")
+    expect(page).to have_link("ID: #{@invoice_7.id}")
+    expect(page).to_not have_link("ID: #{@invoice_8.id}")
   end
 end

--- a/spec/features/merchant/invoices/index_spec.rb
+++ b/spec/features/merchant/invoices/index_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Merchant Invoices Index Page', type: :feature do
   before(:each) do
     @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
 
     @item_1 = create(:item, merchant_id: @merchant_1.id)
     @item_2 = create(:item, merchant_id: @merchant_1.id)
     @item_3 = create(:item, merchant_id: @merchant_1.id)
     @item_4 = create(:item, merchant_id: @merchant_1.id)
     @item_5 = create(:item, merchant_id: @merchant_1.id)
+    @item_6 = create(:item, name: "Does not belong to merchant", merchant_id: @merchant_2.id)
     
     @customer_1 = create(:customer)
     @customer_2 = create(:customer)
@@ -24,6 +26,7 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
     @invoice_5 = create(:invoice, customer_id: @customer_4.id)
     @invoice_6 = create(:invoice, customer_id: @customer_5.id)
     @invoice_7 = create(:invoice, customer_id: @customer_6.id)
+    @invoice_8 = create(:invoice, customer_id: @customer_6.id)
     
     @transaction_1 = create(:transaction, invoice_id: @invoice_1.id, result: true) #customer_1 
     @transaction_2 = create(:transaction, invoice_id: @invoice_1.id, result: true) #customer_1
@@ -56,6 +59,7 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
     @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, status: 2)
     @invoice_item_6 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_6.id, status: 2)
     @invoice_item_7 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_7.id, status: 2)
+    @invoice_item_8 = create(:invoice_item, item_id: @item_6.id, invoice_id: @invoice_8.id, status: 0)
 
     visit merchant_invoices_path(@merchant_1.id)
   end
@@ -64,9 +68,20 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
     expect(page).to have_content("#{@merchant_1.name} Invoices")
   end
 
-  it 'it has invoice ids as links' do
+  it 'it has invoice ids as links, User Story 14' do
     within "#invoice-#{@invoice_1.id}" do
       expect(page).to have_link("ID: #{@invoice_1.id}")
     end
+  end
+
+  it 'when I visit a merchant invoice index page, I see all invoices with at least one of my merchant items (User Story 14)' do
+    expect(page).to have_link(@invoice_1.id)
+    expect(page).to have_link(@invoice_2.id)
+    expect(page).to have_link(@invoice_3.id)
+    expect(page).to have_link(@invoice_4.id)
+    expect(page).to have_link(@invoice_5.id)
+    expect(page).to have_link(@invoice_6.id)
+    expect(page).to have_link(@invoice_7.id)
+    expect(page).to_not have_link(@invoice_8.id)
   end
 end

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
     @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, status: 2)
     @invoice_item_6 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_6.id, status: 2)
     @invoice_item_7 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_7.id, status: 2)
-    @invoice_item_8 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_1.id, status: 2)
+    @invoice_item_8 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_5.id, status: 2)
     @invoice_item_9 = create(:invoice_item, item_id: @item_6.id, invoice_id: @invoice_7.id, status: 2)
   
     visit merchant_invoice_path(@merchant_1, @invoice_1)
@@ -103,9 +103,8 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
   end
 
   it 'will display the total revenue that will be generated from all of my items on the invoice (User Story 17)' do
+    save_and_open_page
     expect(page).to have_content("Total Revenue: $3,400,000")
   end
-#   As a merchant
-# When I visit my merchant invoice show page
-# Then I see the total revenue that will be generated from all of my items on the invoice
+
 end

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -103,37 +103,36 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
   end
 
   it 'will display the total revenue that will be generated from all of my items on the invoice (User Story 17)' do
-    save_and_open_page
     expect(page).to have_content("Total Revenue: $340,000.00")
   end
 
   it 'I will see the invoice item status for the item selected, when I click the select I can select a new status for the item with a button next to that says Update Item Status' do
-    expect(page).to have_button("Update Item Status")
-    expect(page).to have_select("invoice_item_status", selected: "pending")
-    save_and_open_page
-  end
+    within "#item-info-#{@item_1.id}" do
+      within "#selector" do
+      expect(page).to have_button("Update Item Status")
+      expect(page).to have_select("invoice_item_status", options: ['Pending', 'Packaged', 'Shipped'])
+      expect(page).to have_content("Pending")
+      end
+    end
 
-# When I click this button
-# I am taken back to the merchant invoice show page
-# And I see that my Item's status has now been updated
-end
-
-describe 'when I visit my my items index page' do
-  before(:all) do
-    Item.delete_all
-    Merchant.delete_all
-    @merch_1 = create(:merchant)
-    @merch_2 = create(:merchant)
-    create_list(:item, 10, merchant_id: @merch_1.id)
-    create_list(:item, 3, merchant_id: @merch_2.id)
-  end
-it 'displays a list of the names of all my items' do
-    visit "/merchants/#{@merch_1.id}/items"
-    list_of_names = @merch_1.items.pluck('name')
-   
-    within("#my-items-list") do
-      list_of_names.each do |name|
-        expect(page).to have_content(name)
+    within "#item-info-#{@item_2.id}" do
+      within "#selector" do
+        expect(page).to have_button("Update Item Status")
+        expect(page).to have_select("invoice_item_status", options: ['Pending', 'Packaged', 'Shipped'])
+        expect(page).to have_content("Shipped")
       end
     end
   end
+
+  it 'when I select a new status and click the button I am taken back to the show page and see that the status is updated' do
+    within "#item-info-#{@item_1.id}" do
+      within "#selector" do
+        select "Packaged", from: "invoice_item_status"
+        click_button "Update Item Status"
+      end
+
+      expect(current_path).to eq(merchant_invoice_path(@merchant_1, @invoice_1))
+      expect(page).to have_content("Packaged")
+    end
+  end
+end

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Merchant Invoices Show Page', type: :feature do
   before(:each) do
     @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
 
     @item_1 = create(:item, merchant_id: @merchant_1.id)
     @item_2 = create(:item, merchant_id: @merchant_1.id)
     @item_3 = create(:item, merchant_id: @merchant_1.id)
     @item_4 = create(:item, merchant_id: @merchant_1.id)
     @item_5 = create(:item, merchant_id: @merchant_1.id)
+    @item_6 = create(:item, merchant_id: @merchant_2.id)
     
     @customer_1 = create(:customer)
     @customer_2 = create(:customer)
@@ -49,14 +51,15 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
     @transaction_22 = create(:transaction, invoice_id: @invoice_7.id, result: true) #customer_6
     @transaction_23 = create(:transaction, invoice_id: @invoice_7.id, result: false) #customer_6
 
-    @invoice_item_1 = create(:invoice_item, item_id: @item_1.id, invoice_id: @invoice_1.id, status: 0)
-    @invoice_item_2 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_2.id, status: 0)
+    @invoice_item_1 = create(:invoice_item, quantity: 100, unit_price: 15000, item_id: @item_1.id, invoice_id: @invoice_1.id, status: 0)
+    @invoice_item_2 = create(:invoice_item, quantity: 1300, unit_price: 25000, item_id: @item_2.id, invoice_id: @invoice_1.id, status: 2)
     @invoice_item_3 = create(:invoice_item, item_id: @item_3.id, invoice_id: @invoice_3.id, status: 1)
     @invoice_item_4 = create(:invoice_item, item_id: @item_4.id, invoice_id: @invoice_4.id, status: 1)
     @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, status: 2)
     @invoice_item_6 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_6.id, status: 2)
     @invoice_item_7 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_7.id, status: 2)
     @invoice_item_8 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_1.id, status: 2)
+    @invoice_item_9 = create(:invoice_item, item_id: @item_6.id, invoice_id: @invoice_7.id, status: 2)
   
     visit merchant_invoice_path(@merchant_1, @invoice_1)
   end
@@ -65,7 +68,7 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
     expect(page).to have_content('Merchant Invoice Show Page')
   end
 
-  it 'has the related invoice information, id, status, created at date in the format "Monday, July 18, 2019' do 
+  it 'has the related invoice information, id, status, created at date in the format "Monday, July 18, 2019 (User Story 15)' do 
     within '#invoice-info' do  
       expect(page).to have_content(@invoice_1.id)
       expect(page).to have_content(@invoice_1.status)
@@ -73,11 +76,36 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
     end
   end
 
-  it 'will display the customer first and last name' do
+  it 'will display the customer first and last name (User Story 15)' do
     within '#customer-info' do
       expect(page).to have_content("Customer:")
       expect(page).to have_content(@customer_1.first_name)
       expect(page).to have_content(@customer_1.last_name)
     end
   end
+
+  it 'will display the item names, quantity ordered, price sold for, and invoice item status (User Story 16)' do
+    within "#item-info-#{@item_1.id}" do
+      expect(page).to have_content("Item Name: #{@item_1.name}")
+      expect(page).to have_content("Quantity: 100")
+      expect(page).to have_content("Unit Price: $150")
+      expect(page).to have_content("Status: Pending")
+    end
+
+    within "#item-info-#{@item_2.id}" do
+      expect(page).to have_content("Item Name: #{@item_2.name}")
+      expect(page).to have_content("Quantity: 1300")
+      expect(page).to have_content("Unit Price: $250")
+      expect(page).to have_content("Status: Shipped")
+    end
+
+    expect(page).to_not have_content(@item_6.name)
+  end
+
+  it 'will display the total revenue that will be generated from all of my items on the invoice (User Story 17)' do
+    expect(page).to have_content("Total Revenue: $3,400,000")
+  end
+#   As a merchant
+# When I visit my merchant invoice show page
+# Then I see the total revenue that will be generated from all of my items on the invoice
 end

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
     @customer_5 = create(:customer)
     @customer_6 = create(:customer)
 
-    @invoice_1 = create(:invoice, customer_id: @customer_1.id)
+    @invoice_1 = create(:invoice, customer_id: @customer_1.id, created_at: "2012-03-27 14:54:09 UTC")
     @invoice_2 = create(:invoice, customer_id: @customer_1.id)
     @invoice_3 = create(:invoice, customer_id: @customer_2.id)
     @invoice_4 = create(:invoice, customer_id: @customer_3.id)
@@ -56,11 +56,28 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
     @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, status: 2)
     @invoice_item_6 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_6.id, status: 2)
     @invoice_item_7 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_7.id, status: 2)
+    @invoice_item_8 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_1.id, status: 2)
   
     visit merchant_invoice_path(@merchant_1, @invoice_1)
   end
 
   it 'has a header' do
     expect(page).to have_content('Merchant Invoice Show Page')
+  end
+
+  it 'has the related invoice information, id, status, created at date in the format "Monday, July 18, 2019' do 
+    within '#invoice-info' do  
+      expect(page).to have_content(@invoice_1.id)
+      expect(page).to have_content(@invoice_1.status)
+      expect(page).to have_content('Tuesday, March 27, 2012')
+    end
+  end
+
+  it 'will display the customer first and last name' do
+    within '#customer-info' do
+      expect(page).to have_content("Customer:")
+      expect(page).to have_content(@customer_1.first_name)
+      expect(page).to have_content(@customer_1.last_name)
+    end
   end
 end

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -104,7 +104,36 @@ RSpec.describe 'Merchant Invoices Show Page', type: :feature do
 
   it 'will display the total revenue that will be generated from all of my items on the invoice (User Story 17)' do
     save_and_open_page
-    expect(page).to have_content("Total Revenue: $3,400,000")
+    expect(page).to have_content("Total Revenue: $340,000.00")
   end
 
+  it 'I will see the invoice item status for the item selected, when I click the select I can select a new status for the item with a button next to that says Update Item Status' do
+    expect(page).to have_button("Update Item Status")
+    expect(page).to have_select("invoice_item_status", selected: "pending")
+    save_and_open_page
+  end
+
+# When I click this button
+# I am taken back to the merchant invoice show page
+# And I see that my Item's status has now been updated
 end
+
+describe 'when I visit my my items index page' do
+  before(:all) do
+    Item.delete_all
+    Merchant.delete_all
+    @merch_1 = create(:merchant)
+    @merch_2 = create(:merchant)
+    create_list(:item, 10, merchant_id: @merch_1.id)
+    create_list(:item, 3, merchant_id: @merch_2.id)
+  end
+it 'displays a list of the names of all my items' do
+    visit "/merchants/#{@merch_1.id}/items"
+    list_of_names = @merch_1.items.pluck('name')
+   
+    within("#my-items-list") do
+      list_of_names.each do |name|
+        expect(page).to have_content(name)
+      end
+    end
+  end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -94,13 +94,13 @@ RSpec.describe Invoice, type: :model do
         item_1 = create(:item, merchant_id: merchant_1.id)
         item_2 = create(:item, merchant_id: merchant_1.id)
         item_3 = create(:item, merchant_id: merchant_1.id)
-        invoice_item_1 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_1.id, quantity: 1, unit_price: 100)
-        invoice_item_2 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_2.id, quantity: 100, unit_price: 10)
-        invoice_item_3 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_3.id, quantity: 5, unit_price: 50)
+        invoice_item_1 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_1.id, quantity: 10, unit_price: 1000)
+        invoice_item_2 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_2.id, quantity: 1000, unit_price: 100)
+        invoice_item_3 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_3.id, quantity: 50, unit_price: 500)
 
         invoice_item_4 = create(:invoice_item, invoice_id: invoice_2.id, item_id: item_1.id, quantity: 0, unit_price: 0)
-        invoice_item_5= create(:invoice_item, invoice_id: invoice_2.id, item_id: item_2.id, quantity: 6, unit_price: 6)
-        invoice_item_6 = create(:invoice_item, invoice_id: invoice_2.id, item_id: item_3.id, quantity: 5, unit_price: 4)
+        invoice_item_5= create(:invoice_item, invoice_id: invoice_2.id, item_id: item_2.id, quantity: 60, unit_price: 60)
+        invoice_item_6 = create(:invoice_item, invoice_id: invoice_2.id, item_id: item_3.id, quantity: 50, unit_price: 40)
 
         expect(invoice_1.total_revenue).to eq(1350)
         expect(invoice_2.total_revenue).to eq(56)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Invoice, type: :model do
         item_2 = create(:item, merchant_id: merchant_1.id)
         item_3 = create(:item, merchant_id: merchant_1.id)
         invoice_item_1 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_1.id, quantity: 1, unit_price: 100)
-        invoice_item_2= create(:invoice_item, invoice_id: invoice_1.id, item_id: item_2.id, quantity: 100, unit_price: 10)
+        invoice_item_2 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_2.id, quantity: 100, unit_price: 10)
         invoice_item_3 = create(:invoice_item, invoice_id: invoice_1.id, item_id: item_3.id, quantity: 5, unit_price: 50)
 
         invoice_item_4 = create(:invoice_item, invoice_id: invoice_2.id, item_id: item_1.id, quantity: 0, unit_price: 0)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Item, type: :model do
 
     describe "#find_sold_price" do
       it "finds the price the item sold for in a particular invoice_item" do
-        expect(@item_1.find_sold_price(@invoice_1)).to eq([@invoice_item_1.unit_price])
-        expect(@item_2.find_sold_price(@invoice_1)).to eq([@invoice_item_2.unit_price])
-        expect(@item_1.find_sold_price(@invoice_2)).to eq([@invoice_item_3.unit_price])
+        expect(@item_1.find_sold_price(@invoice_1)).to eq(@invoice_item_1.unit_price.fdiv(100))
+        expect(@item_2.find_sold_price(@invoice_1)).to eq(@invoice_item_2.unit_price.fdiv(100))
+        expect(@item_1.find_sold_price(@invoice_2)).to eq(@invoice_item_3.unit_price.fdiv(100))
       end
     end
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Merchant, type: :model do
       @transaction_18 = create(:transaction, invoice_id: @invoice_5.id, result: true) #customer_4
       @transaction_19 = create(:transaction, invoice_id: @invoice_6.id, result: true) #customer_5
       @transaction_20 = create(:transaction, invoice_id: @invoice_6.id, result: true) #customer_5
-      @transaction_21= create(:transaction, invoice_id: @invoice_6.id, result: false) #customer_5
+      @transaction_21 = create(:transaction, invoice_id: @invoice_6.id, result: false) #customer_5
       @transaction_22 = create(:transaction, invoice_id: @invoice_7.id, result: true) #customer_6
       @transaction_23 = create(:transaction, invoice_id: @invoice_7.id, result: false) #customer_6
 


### PR DESCRIPTION
This PR completes User Stories 14-18 dealing with merchant invoices.
-Merchant Invoices Index: lists all invoices with at least one of the merchant items and each invoice is a link to the merchant invoice show page.
-That merchant invoice show displays the invoice id, status, created at, and customer first and last name.
-Invoice Item Information of item name, quantity ordered, price item sold for, and invoice items status is displayed.
-Displays total revenue for that merchant
-Has a form to update an invoice item status that changes the status and displays what the current status is.

All feature and model tests passing with 100% coverage.