### PR TITLE
API User Story 2

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -6,6 +6,7 @@ class Merchant::ItemsController < ApplicationController
   end
 
   def show
+    @photo = PhotoSearch.new.search_result(@item.name)
   end
 
   def new

--- a/app/views/merchant/items/show.html.erb
+++ b/app/views/merchant/items/show.html.erb
@@ -7,4 +7,8 @@
 <h3><%= @item.name %></h3>
 
 <p>Description: <%= @item.description %></p>
-<p>Current Unit Price: <%= @item.unit_price %></p>
+<p>Current Unit Price: <%= format_currency(@item.unit_price) %></p>
+
+<div id="item-image">
+  <%= image_tag @photo.small_url %>
+</div>

--- a/spec/features/merchant/items/show_spec.rb
+++ b/spec/features/merchant/items/show_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe 'Merchant Item Show Page', type: :feature do
   before(:each) do
     @merchant_1 = create(:merchant)
-    @item_1 = create(:item, merchant: @merchant_1)
+    @item_1 = create(:item, name: "Cat", merchant: @merchant_1)
+    @item_2 = create(:item, name: "Dog", merchant: @merchant_1)
+    @item_3 = create(:item, name: "Assumenda Animi", merchant: @merchant_1)
 
     visit merchant_item_path(@merchant_1.id, @item_1)
   end
@@ -25,7 +27,30 @@ RSpec.describe 'Merchant Item Show Page', type: :feature do
     it 'displays the details of the item' do
       expect(page).to have_content(@item_1.name)
       expect(page).to have_content("Description: #{@item_1.description}")
-      expect(page).to have_content("Current Unit Price: #{@item_1.unit_price}")
+      expect(page).to have_content("Current Unit Price: $#{@item_1.unit_price.fdiv(100)}")
+    end
+  end
+
+  describe 'Item Image (API User Story 2)' do
+    it 'displays a photo related to that items name' do
+
+      within "#item-image" do
+        expect(page).to have_css('img')
+      end
+
+      visit merchant_item_path(@merchant_1, @item_2)
+
+      within "#item-image" do
+        expect(page).to have_css('img')
+      end
+    end
+
+    it 'displays an expected failure image when no photos match the search by item name' do
+      visit merchant_item_path(@merchant_1, @item_3)
+
+      within "#item-image" do
+        expect(page).to have_css('img')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds an image related to the item's name to the Merchant Items Show page.  It also adds tests to expect an image on each page.

There are two happy path tests with known item names (where photos are found) and one "sad path" test for an image where no photos are found on Unsplash for the given item name search.

In this case, this is handled in the Service Object method and a default photo is substituted. The test checks that an image is still rendered on the page even when no results are found from the initial call to the API with search terms.