### PR TITLE
fix: add migration to add status to merchants

### DIFF
--- a/db/migrate/20230410224299_create_merchants.rb
+++ b/db/migrate/20230410224299_create_merchants.rb
@@ -3,7 +3,7 @@ class CreateMerchants < ActiveRecord::Migration[5.2]
     create_table :merchants do |t|
 
       t.string :name, null: false
-      t.boolean :is_enabled, default: false
+
       t.timestamp :created_at, null: false
       t.timestamp :updated_at, null: false
     end

--- a/db/migrate/20230419225524_add_enabled_or_disabled_status_to_merchants.rb
+++ b/db/migrate/20230419225524_add_enabled_or_disabled_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddEnabledOrDisabledStatusToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :is_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_16_073636) do
+ActiveRecord::Schema.define(version: 2023_04_19_225524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,9 +55,9 @@ ActiveRecord::Schema.define(version: 2023_04_16_073636) do
 
   create_table "merchants", force: :cascade do |t|
     t.string "name", null: false
-    t.boolean "is_enabled", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_enabled", default: false, null: false
   end
 
   create_table "transactions", force: :cascade do |t|


### PR DESCRIPTION
This PR fixes an issue with the migration that adds the is_enabled column to the Merchants table.  It adds a new migration to add this column, with a default value of false.